### PR TITLE
Clarify summary with specific subdirectory name

### DIFF
--- a/quickstart.html
+++ b/quickstart.html
@@ -403,7 +403,7 @@ directories to their respective branches on GitHub.  You must supply the commit 
 
 <ul>
 <li>Invoke the morea-run-local.sh script.</li>
-<li>Edit the contents of the morea/ directory.</li>
+<li>Edit the contents within the master/src/morea/ subdirectory.</li>
 <li>Review your changes privately at <a href="http://localhost:4000">http://localhost:4000</a>.</li>
 <li>When ready, invoke the morea-publish.sh script to publish your changes to the world.</li>
 </ul>


### PR DESCRIPTION
The summary states that the user should edit the morea/ directory.
Clarifying this with the specific subdirectory name assists new users (did they mean "master"? Hm, where is the morea directory? Ah, it's nested two levels within the generated master directory.)
