### PR TITLE
Another option for embedding slides

### DIFF
--- a/userguide.html
+++ b/userguide.html
@@ -1425,6 +1425,16 @@ in your markdown.</p>
 
 <p><img src="images/speakerdeck-mobile.png" width="400px" class="img-responsive"/></p>
 
+<p> A somewhat simpler approach is to host the slides pdfs with the other materials and use an &lt;embed&gt; html element, e.g.,</p>
+
+<figure class="highlight"><pre><code class="language-yaml" data-lang="yaml">
+<span class="nn">---</span>
+
+<span class="c1">## Lecture Notes: Sequential Warmup</span>
+
+<span class="l-Scalar-Plain">&lt;embed src=&quot;./lecture.pdf&quot; type='application/pdf'&gt;</span>
+</code></pre></figure>
+
 <h2>Google analytics</h2>
 
 <p>If you are interesting in tracking usage of your pages, Morea supports <a href="http://www.google.com/analytics/">Google Analytics</a>.  </p>


### PR DESCRIPTION
The suggested SpeakerDeck hosting is somewhat limited since links inside a pdf are not clickable, I found it easier to just embed the pdf with the other materials
